### PR TITLE
Run server on seperate thread and decentralized command handling logic

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{engine::{command_registry::{self}, state::State, time::Time}};
+use crate::engine::{command_registry::{self, DebugCommandWithArgs}, state::State, time::Time};
 use winit::{application::ApplicationHandler, event::{KeyEvent, WindowEvent}, event_loop::{ActiveEventLoop}, keyboard::{KeyCode, PhysicalKey}, window::{Window, WindowId}};
 use std::{sync::{mpsc::Receiver, Arc}};
 use crate::engine::util::{AppConfig};
@@ -6,13 +6,13 @@ use crate::engine::util::{AppConfig};
 pub struct App {
     state: Option<State>,
     pub time: Time,
-    console_listener: Receiver<String>,
+    console_listener: Receiver<DebugCommandWithArgs>,
     server_listener: Receiver<String>,
     pub app_config: AppConfig,
 }
 
 impl App {
-    pub fn new(console_listener: Receiver<String>, server_listener: Receiver<String>) -> Self {
+    pub fn new(console_listener: Receiver<DebugCommandWithArgs>, server_listener: Receiver<String>) -> Self {
         Self {
             state: None,
             time: Time::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
-use crate::engine::{command_registry::{self, DebugCommand}, server::server::Server, state::State, time::Time};
+use crate::{engine::{command_registry::{self}, state::State, time::Time}};
 use winit::{application::ApplicationHandler, event::{KeyEvent, WindowEvent}, event_loop::{ActiveEventLoop}, keyboard::{KeyCode, PhysicalKey}, window::{Window, WindowId}};
-use std::{collections::HashMap, sync::{mpsc::Receiver, Arc}};
+use std::{sync::{mpsc::Receiver, Arc}};
 use crate::engine::util::{AppConfig};
 
 pub struct App {
@@ -9,7 +9,6 @@ pub struct App {
     console_listener: Receiver<String>,
     server_listener: Receiver<String>,
     pub app_config: AppConfig,
-    pub command_registry: HashMap<&'static str, DebugCommand>,
 }
 
 impl App {
@@ -20,7 +19,6 @@ impl App {
             console_listener: console_listener,
             server_listener: server_listener,
             app_config: AppConfig::default(),
-            command_registry: command_registry::build_registry(),
         }
     }
 }
@@ -96,10 +94,6 @@ impl App {
     fn on_launch(&mut self) {
 
     }
-    
-    fn on_tick(_delta_time: f32, server: &mut Server) {
-        
-    }
 
     fn on_update_frame(&mut self) {
         // Input/UI/scripting here
@@ -126,7 +120,7 @@ impl App {
 
     fn on_handle_command(&mut self) {
         while let Ok(cmd) = self.console_listener.try_recv() {
-            command_registry::handle_command(self, &cmd);
+            command_registry::handle_client_command(self, &cmd);
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,20 +7,20 @@ pub struct App {
     state: Option<State>,
     pub time: Time,
     console_listener: Receiver<String>,
+    server_listener: Receiver<String>,
     pub app_config: AppConfig,
     pub command_registry: HashMap<&'static str, DebugCommand>,
-    pub server: Option<Server>,
 }
 
 impl App {
-    pub fn new(listener: Receiver<String>) -> Self {
+    pub fn new(console_listener: Receiver<String>, server_listener: Receiver<String>) -> Self {
         Self {
             state: None,
             time: Time::new(),
-            console_listener: listener,
+            console_listener: console_listener,
+            server_listener: server_listener,
             app_config: AppConfig::default(),
             command_registry: command_registry::build_registry(),
-            server: None,
         }
     }
 }
@@ -79,12 +79,6 @@ impl ApplicationHandler for App {
         if redraw_requested {
             self.time.update();
             self.on_handle_command();
-            match &mut self.server {
-                Some(server) => {
-                    App::on_tick(self.time.delta_time(), server);
-                },
-                None => {},
-            }
             self.on_update_frame();
             self.on_render();
             if let Some(state) = &mut self.state {
@@ -100,13 +94,11 @@ impl ApplicationHandler for App {
 
 impl App {
     fn on_launch(&mut self) {
-        self.server = Some(Server::start_server());
+
     }
     
     fn on_tick(_delta_time: f32, server: &mut Server) {
-        for dimension in server.dimensions.values_mut() {
-            dimension.load_chunks();
-        }
+        
     }
 
     fn on_update_frame(&mut self) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,16 +1,8 @@
-use std::collections::HashMap;
-
 use clap::{ValueEnum};
-
-use crate::engine::command_registry::DebugCommand;
 
 #[derive(Clone, Debug, ValueEnum)]
 pub enum Environment {
     Both,
     Client,
     Server,
-}
-
-pub struct CommandRegistry {
-    pub global_registry: HashMap<&'static str, DebugCommand>,
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,16 @@
+use std::collections::HashMap;
+
 use clap::{ValueEnum};
+
+use crate::engine::command_registry::DebugCommand;
 
 #[derive(Clone, Debug, ValueEnum)]
 pub enum Environment {
     Both,
     Client,
     Server,
+}
+
+pub struct CommandRegistry {
+    pub global_registry: HashMap<&'static str, DebugCommand>,
 }

--- a/src/engine/client/commands.rs
+++ b/src/engine/client/commands.rs
@@ -7,7 +7,7 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
         name: "framerate",
         aliases: &["fps"],
         description: "Prints the average framerate. Sampled since program start, or last resetfps execution.",
-        execute: |dependency, _args: &[&str]| {
+        execute: |dependency, _args| {
             if let CommandDependency::App(app) = dependency {
                 println!("Average FPS: {:.2}", app.time.average_fps());
             }

--- a/src/engine/client/commands.rs
+++ b/src/engine/client/commands.rs
@@ -1,4 +1,4 @@
-use crate::engine::command_registry::{error_not_enough_arguments, error_wrong_type, DebugCommand};
+use crate::engine::command_registry::{error_not_enough_arguments, error_wrong_type, CommandEnvironment, DebugCommand};
 
 pub fn create_client_commands() -> Vec<DebugCommand> {
     let mut commands = Vec::new();
@@ -10,6 +10,7 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
         execute: |_app, _args| {
             println!("Average FPS: {:.2}", _app.time.average_fps());
         },
+        command_environment: CommandEnvironment::Client,
     });
 
     commands.push(DebugCommand {
@@ -28,6 +29,7 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
                 error_not_enough_arguments();
             }      
         },
+        command_environment: CommandEnvironment::Client,
     });
 
     commands.push(DebugCommand {
@@ -38,6 +40,7 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
             _app.time.reset_average_fps();
             println!("Reset average framerate sample frames")
         },
+        command_environment: CommandEnvironment::Client,
     });
 
     commands.push(DebugCommand {
@@ -48,7 +51,8 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
             app.app_config.vsync = !app.app_config.vsync;
             let bool = app.app_config.vsync;
             println!("VSync toggled to {bool}");
-        }
+        },
+        command_environment: CommandEnvironment::Client,
     });
 
     return commands;

--- a/src/engine/client/commands.rs
+++ b/src/engine/client/commands.rs
@@ -1,4 +1,4 @@
-use crate::engine::command_registry::{error_not_enough_arguments, error_wrong_type, CommandEnvironment, DebugCommand};
+use crate::engine::command_registry::{error_not_enough_arguments, error_wrong_type, CommandDependency, CommandEnvironment, DebugCommand};
 
 pub fn create_client_commands() -> Vec<DebugCommand> {
     let mut commands = Vec::new();
@@ -7,8 +7,10 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
         name: "framerate",
         aliases: &["fps"],
         description: "Prints the average framerate. Sampled since program start, or last resetfps execution.",
-        execute: |_app, _args| {
-            println!("Average FPS: {:.2}", _app.time.average_fps());
+        execute: |dependency, _args: &[&str]| {
+            if let CommandDependency::App(app) = dependency {
+                println!("Average FPS: {:.2}", app.time.average_fps());
+            }
         },
         command_environment: CommandEnvironment::Client,
     });
@@ -17,17 +19,19 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
         name: "setfps",
         aliases: &["setfps", "setframerate"],
         description: "Sets the target framerate.",
-        execute: |_app, _args| {
-            if let Some(arg) = _args.first() {
-                if let Ok(new_cap) = arg.parse::<u32>() {
-                    _app.app_config.frame_cap = new_cap;
-                    println!("Frame cap set to {new_cap}");
+        execute: |dependency, _args| {
+            if let CommandDependency::App(app) = dependency {
+                if let Some(arg) = _args.first() {
+                    if let Ok(new_cap) = arg.parse::<u32>() {
+                        app.app_config.frame_cap = new_cap;
+                        println!("Frame cap set to {new_cap}");
+                    } else {
+                        error_wrong_type();
+                    }
                 } else {
-                    error_wrong_type();
+                    error_not_enough_arguments();
                 }
-            } else {
-                error_not_enough_arguments();
-            }      
+            }
         },
         command_environment: CommandEnvironment::Client,
     });
@@ -36,9 +40,11 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
         name: "resetfps",
         aliases: &["rfps"],
         description: "Resets the average framerate sample frames.",
-        execute: |_app, _args| {
-            _app.time.reset_average_fps();
-            println!("Reset average framerate sample frames")
+        execute: |dependency, _args| {
+            if let CommandDependency::App(app) = dependency {
+                app.time.reset_average_fps();
+                println!("Reset average framerate sample frames")
+            }
         },
         command_environment: CommandEnvironment::Client,
     });
@@ -47,10 +53,12 @@ pub fn create_client_commands() -> Vec<DebugCommand> {
         name: "togglevsync",
         aliases: &["tvsync"],
         description: "Toggles VSync.",
-        execute: |app, _args| {
-            app.app_config.vsync = !app.app_config.vsync;
-            let bool = app.app_config.vsync;
-            println!("VSync toggled to {bool}");
+        execute: |dependency, _args| {
+            if let CommandDependency::App(app) = dependency {
+                app.app_config.vsync = !app.app_config.vsync;
+                let bool = app.app_config.vsync;
+                println!("VSync toggled to {bool}");
+            }
         },
         command_environment: CommandEnvironment::Client,
     });

--- a/src/engine/command_registry.rs
+++ b/src/engine/command_registry.rs
@@ -92,7 +92,3 @@ pub fn error_command_not_found() {
 pub fn error_dimension_not_found() {
     println!("Failed to execute command - the dimension you were looking for could not be found.")
 }
-
-pub fn error_server_not_started() {
-    println!("Failed to execute command - the server has not been started.")
-}

--- a/src/engine/command_registry.rs
+++ b/src/engine/command_registry.rs
@@ -1,5 +1,12 @@
 use std::collections::HashMap;
-use crate::{common::Environment, engine::{client::{self, commands::create_client_commands}, commands::create_general_commands, server::commands::create_server_commands}, get_environment, App};
+use crate::{common::Environment, engine::{client::{self, commands::create_client_commands}, commands::create_main_commands, server::commands::create_server_commands}, get_environment, App};
+
+#[derive(Eq, PartialEq, Hash, Clone, Copy)]
+pub enum CommandEnvironment {
+    Client,
+    Server,
+    Main,
+}
 
 #[derive(Eq, PartialEq, Hash)]
 pub struct DebugCommand {
@@ -7,11 +14,12 @@ pub struct DebugCommand {
     pub aliases: &'static [&'static str],
     pub description: &'static str,
     pub execute: fn(&mut App, &[&str]),
+    pub command_environment: CommandEnvironment,
 }
 
 pub fn build_registry() -> HashMap<&'static str, DebugCommand> {
     let mut mapped = HashMap::new();
-    let mut commands = create_general_commands();
+    let mut commands = create_main_commands();
 
     match get_environment() {
         Environment::Client => {commands.extend(create_client_commands())},
@@ -26,6 +34,7 @@ pub fn build_registry() -> HashMap<&'static str, DebugCommand> {
                 aliases: cmd.aliases,
                 description: cmd.description,
                 execute: cmd.execute,
+                command_environment: cmd.command_environment,
             });
         }
         mapped.insert(cmd.name, cmd);

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -1,8 +1,8 @@
 use sysinfo::System;
 
-use crate::{app::App, engine::command_registry::{error_command_not_found, error_not_enough_arguments, DebugCommand}};
+use crate::{app::App, engine::command_registry::{error_command_not_found, error_not_enough_arguments, CommandEnvironment, DebugCommand}};
 
-pub fn create_general_commands() -> Vec<DebugCommand> {
+pub fn create_main_commands() -> Vec<DebugCommand> {
     let mut commands = Vec::new();
 
     commands.push(DebugCommand {
@@ -11,7 +11,8 @@ pub fn create_general_commands() -> Vec<DebugCommand> {
         description: "Prints the help menu.",
         execute: |_app, _args| {
             print_debug_menu(_app);
-        }
+        },
+        command_environment: CommandEnvironment::Main,
     });
 
     commands.push(DebugCommand {
@@ -20,7 +21,8 @@ pub fn create_general_commands() -> Vec<DebugCommand> {
         description: "Prints program memory usage.",
         execute: |_app, _args| {
             print_memory_usage();
-        }
+        },
+        command_environment: CommandEnvironment::Main,
     });
 
     commands.push(DebugCommand {
@@ -37,7 +39,8 @@ pub fn create_general_commands() -> Vec<DebugCommand> {
             } else {
                 error_not_enough_arguments();
             }
-        }
+        },
+        command_environment: CommandEnvironment::Main,
     });
 
     commands.push(DebugCommand {
@@ -46,7 +49,8 @@ pub fn create_general_commands() -> Vec<DebugCommand> {
         description: "Kills the process. Warning - just close the window normally if you can.",
         execute: |_app, _args| {
             std::process::exit(0);
-        }
+        },
+        command_environment: CommandEnvironment::Main,
     });
     
     return commands;

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -34,7 +34,7 @@ pub fn create_main_commands() -> Vec<DebugCommand> {
         execute: |dependency, _args| {
             if let CommandDependency::Main = dependency {
                 if let Some(arg) = _args.first() {
-                    if get_global_command_registry().contains_key(arg) {
+                    if get_global_command_registry().contains_key(arg.as_str()) {
                         print_aliases(arg);
                     } else {
                         error_command_not_found();

--- a/src/engine/commands.rs
+++ b/src/engine/commands.rs
@@ -1,6 +1,6 @@
 use sysinfo::System;
 
-use crate::{app::App, engine::command_registry::{error_command_not_found, error_not_enough_arguments, CommandEnvironment, DebugCommand}};
+use crate::{engine::command_registry::{error_command_not_found, error_not_enough_arguments, CommandDependency, CommandEnvironment, DebugCommand}, get_global_command_registry};
 
 pub fn create_main_commands() -> Vec<DebugCommand> {
     let mut commands = Vec::new();
@@ -9,8 +9,10 @@ pub fn create_main_commands() -> Vec<DebugCommand> {
         name: "help",
         aliases: &["h", "m"],
         description: "Prints the help menu.",
-        execute: |_app, _args| {
-            print_debug_menu(_app);
+        execute: |dependency, _args| {
+            if let CommandDependency::Main = dependency {
+                print_debug_menu();
+            }
         },
         command_environment: CommandEnvironment::Main,
     });
@@ -19,7 +21,7 @@ pub fn create_main_commands() -> Vec<DebugCommand> {
         name: "memory",
         aliases: &["mem"],
         description: "Prints program memory usage.",
-        execute: |_app, _args| {
+        execute: |_dependency, _args| {
             print_memory_usage();
         },
         command_environment: CommandEnvironment::Main,
@@ -29,15 +31,17 @@ pub fn create_main_commands() -> Vec<DebugCommand> {
         name: "alias",
         aliases: &["a"],
         description: ("Prints the aliases of a given command."),
-        execute: |_app, _args| {
-            if let Some(arg) = _args.first() {
-                if _app.command_registry.contains_key(arg) {
-                    print_aliases(_app, arg);
+        execute: |dependency, _args| {
+            if let CommandDependency::Main = dependency {
+                if let Some(arg) = _args.first() {
+                    if get_global_command_registry().contains_key(arg) {
+                        print_aliases(arg);
+                    } else {
+                        error_command_not_found();
+                    }
                 } else {
-                    error_command_not_found();
+                    error_not_enough_arguments();
                 }
-            } else {
-                error_not_enough_arguments();
             }
         },
         command_environment: CommandEnvironment::Main,
@@ -56,10 +60,10 @@ pub fn create_main_commands() -> Vec<DebugCommand> {
     return commands;
 }
 
-fn print_debug_menu(app: &mut App) {
+fn print_debug_menu() {
     println!("Available commands:");
     let mut seen = std::collections::HashSet::new();
-    for (_, cmd) in &app.command_registry {
+    for (_, cmd) in get_global_command_registry() {
         if seen.insert(cmd.description) {
             println!("- {:<12} {}", cmd.name, cmd.description);
         }
@@ -83,8 +87,8 @@ fn print_memory_usage() {
     }
 }
 
-fn print_aliases(app: &mut App, target_name: &str) {
-    let target_command = &app.command_registry.get(target_name).unwrap();
+fn print_aliases(target_name: &str) {
+    let target_command = get_global_command_registry().get(target_name).unwrap();
     let aliases = target_command.aliases;
 
     println!("Available aliases for {target_name}:");

--- a/src/engine/server/commands.rs
+++ b/src/engine/server/commands.rs
@@ -1,4 +1,4 @@
-use crate::{app::App, engine::{command_registry::{error_dimension_not_found, error_not_enough_arguments, error_server_not_started, error_wrong_type, CommandEnvironment, DebugCommand}, server::constants::CHUNK_BLOCK_COUNT}};
+use crate::{engine::{command_registry::{error_dimension_not_found, error_not_enough_arguments, error_wrong_type, CommandDependency, CommandEnvironment, DebugCommand}, server::constants::CHUNK_BLOCK_COUNT}};
 
 pub fn create_server_commands() -> Vec<DebugCommand> {
     let mut commands = Vec::new();
@@ -7,15 +7,12 @@ pub fn create_server_commands() -> Vec<DebugCommand> {
         name: "dimensions",
         aliases: &["dims"],
         description: "Returns all dimension names.",
-        execute: |_app, _args| {
-            let Some(server) = &_app.server else {
-            error_server_not_started();
-            return;
-            };
-
-            let keys = server.get_dimension_keys();
-            for key in keys {
-                println!("{}", key);
+        execute: |dependency, _args| {
+            if let CommandDependency::Server(server) = dependency {
+                let keys = server.get_dimension_keys();
+                for key in keys {
+                    println!("{}", key);
+                }
             }
         },
         command_environment: CommandEnvironment::Server,
@@ -25,64 +22,61 @@ pub fn create_server_commands() -> Vec<DebugCommand> {
         name: "testchunkspeed",
         aliases: &["tcs"],
         description: "Generates chunks for 5 seconds then returns the count.",
-        execute: |_app: &mut App, _args: &[&str]| {
-            let Some(server) = &mut _app.server else {
-                error_server_not_started();
-                return;
-            };
-        
-            let Some(dimension_arg) = _args.first() else {
-                error_not_enough_arguments();
-                return;
-            };
+        execute: |dependency, _args: &[&str]| {
+            if let CommandDependency::Server(server) = dependency {  
+                let Some(dimension_arg) = _args.first() else {
+                    error_not_enough_arguments();
+                    return;
+                };
 
-            let Some(dimension) = server.get_dimension(dimension_arg) else {
-                error_dimension_not_found();
-                return;
-            };
+                let Some(dimension) = server.get_dimension(dimension_arg) else {
+                    error_dimension_not_found();
+                    return;
+                };
 
-            let mut chunk_limit: u32 = 10000;
-            if let Some(arg) = _args.get(1) {
-                match arg.parse::<u32>() {
-                    Ok(limit) => chunk_limit = limit,
-                    Err(_) => {
-                        error_wrong_type();
-                        return;
+                let mut chunk_limit: u32 = 10000;
+                if let Some(arg) = _args.get(1) {
+                    match arg.parse::<u32>() {
+                        Ok(limit) => chunk_limit = limit,
+                        Err(_) => {
+                            error_wrong_type();
+                            return;
+                        }
                     }
+                } else {
+                    println!("No limit provided, defaulting to {chunk_limit}");
                 }
-            } else {
-                println!("No limit provided, defaulting to {chunk_limit}");
-            }
 
-            let mut test_count: u32 = 1;
-            if let Some(arg) = _args.get(2) {
-                match arg.parse::<u32>() {
-                    Ok(count) => test_count = if count == 0 { 1 } else { count },
-                    Err(_) => {
-                        error_wrong_type();
-                        return;
+                let mut test_count: u32 = 1;
+                if let Some(arg) = _args.get(2) {
+                    match arg.parse::<u32>() {
+                        Ok(count) => test_count = if count == 0 { 1 } else { count },
+                        Err(_) => {
+                            error_wrong_type();
+                            return;
+                        }
                     }
+                } else {
+                    println!("No test loop count provided, defaulting to {test_count}");
                 }
-            } else {
-                println!("No test loop count provided, defaulting to {test_count}");
+
+                let mut total_nanos: u128 = 0;
+
+                for _ in 0..test_count {
+                    let duration: std::time::Duration = dimension.chunk_load_speed_test(chunk_limit);
+                    total_nanos += duration.as_nanos();
+                }
+
+                let nanos_per_test = total_nanos / test_count as u128;
+                let millis_per_test = nanos_per_test / 1000000;
+
+                println!("Generated {chunk_limit} chunks in {millis_per_test} millis ({nanos_per_test} nanoseconds) ({test_count} tests averaged)");
+
+                let avg_per_chunk = millis_per_test as f64 / chunk_limit as f64;
+                let avg_per_block = (nanos_per_test as f64 / chunk_limit as f64) / CHUNK_BLOCK_COUNT as f64;
+
+                println!("Thats {avg_per_chunk}ms per chunk, {avg_per_block}ns per block ({CHUNK_BLOCK_COUNT} blocks in chunk)");
             }
-
-            let mut total_nanos: u128 = 0;
-
-            for _ in 0..test_count {
-                let duration: std::time::Duration = dimension.chunk_load_speed_test(chunk_limit);
-                total_nanos += duration.as_nanos();
-            }
-
-            let nanos_per_test = total_nanos / test_count as u128;
-            let millis_per_test = nanos_per_test / 1000000;
-
-            println!("Generated {chunk_limit} chunks in {millis_per_test} millis ({nanos_per_test} nanoseconds) ({test_count} tests averaged)");
-            
-            let avg_per_chunk = millis_per_test as f64 / chunk_limit as f64;
-            let avg_per_block = (nanos_per_test as f64 / chunk_limit as f64) / CHUNK_BLOCK_COUNT as f64;
-            
-            println!("Thats {avg_per_chunk}ms per chunk, {avg_per_block}ns per block ({CHUNK_BLOCK_COUNT} blocks in chunk)");
         },
         command_environment: CommandEnvironment::Server,
     });

--- a/src/engine/server/commands.rs
+++ b/src/engine/server/commands.rs
@@ -22,7 +22,7 @@ pub fn create_server_commands() -> Vec<DebugCommand> {
         name: "testchunkspeed",
         aliases: &["tcs"],
         description: "Generates chunks for 5 seconds then returns the count.",
-        execute: |dependency, _args: &[&str]| {
+        execute: |dependency, _args| {
             if let CommandDependency::Server(server) = dependency {  
                 let Some(dimension_arg) = _args.first() else {
                     error_not_enough_arguments();

--- a/src/engine/server/commands.rs
+++ b/src/engine/server/commands.rs
@@ -1,4 +1,4 @@
-use crate::{app::App, engine::{command_registry::{error_dimension_not_found, error_not_enough_arguments, error_server_not_started, error_wrong_type, DebugCommand}, server::constants::CHUNK_BLOCK_COUNT}};
+use crate::{app::App, engine::{command_registry::{error_dimension_not_found, error_not_enough_arguments, error_server_not_started, error_wrong_type, CommandEnvironment, DebugCommand}, server::constants::CHUNK_BLOCK_COUNT}};
 
 pub fn create_server_commands() -> Vec<DebugCommand> {
     let mut commands = Vec::new();
@@ -17,7 +17,8 @@ pub fn create_server_commands() -> Vec<DebugCommand> {
             for key in keys {
                 println!("{}", key);
             }
-        }
+        },
+        command_environment: CommandEnvironment::Server,
     });
 
     commands.push(DebugCommand {
@@ -82,7 +83,8 @@ pub fn create_server_commands() -> Vec<DebugCommand> {
             let avg_per_block = (nanos_per_test as f64 / chunk_limit as f64) / CHUNK_BLOCK_COUNT as f64;
             
             println!("Thats {avg_per_chunk}ms per chunk, {avg_per_block}ns per block ({CHUNK_BLOCK_COUNT} blocks in chunk)");
-        }
+        },
+        command_environment: CommandEnvironment::Server,
     });
 
     return commands;

--- a/src/engine/server/constants.rs
+++ b/src/engine/server/constants.rs
@@ -3,3 +3,5 @@
 // it is only put on the heap once it enters the hashmap
 pub const CHUNK_SIZE: usize = 64;
 pub const CHUNK_BLOCK_COUNT: usize = CHUNK_SIZE * CHUNK_SIZE;
+
+pub const TICK_RATE: u64 = 60;

--- a/src/engine/server/server.rs
+++ b/src/engine/server/server.rs
@@ -13,6 +13,12 @@ impl Server {
         return Server { dimensions: (starting_dimensions) }
     }
 
+    pub fn on_tick(&mut self) {
+        for dimension in self.dimensions.values_mut() {
+            dimension.load_chunks();
+        }
+    }
+
     pub fn get_dimension(&self, name: &str) -> Option<&Dimension> {
         return self.dimensions.get(name);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,34 +2,77 @@ mod app;
 mod engine;
 mod common;
 
-use std::{sync::LazyLock};
+use std::{sync::LazyLock, time::{Duration, Instant}};
 
 use app::App;
 use winit::{event_loop::{EventLoop, ControlFlow}};
 use clap::Parser;
 
-use crate::common::Environment;
+use crate::{common::Environment, engine::server::{constants::TICK_RATE, server::Server}};
 
 
 fn main() {
     env_logger::init();
 
+    let (tx_input, rx_input) = std::sync::mpsc::channel::<String>();
+    let (tx_server, rx_server) = std::sync::mpsc::channel::<String>();
+
     let event_loop = EventLoop::new().unwrap();
     event_loop.set_control_flow(ControlFlow::Poll);
 
-    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    let mut app: App = App::new(rx_input, rx_server);
     
-    let mut app: App = App::new(rx);
+    // Spawn the server thread
+    std::thread::spawn(move || {
+        println!("Server thread spawned");
+
+        let tick_duration = Duration::from_micros(1_000_000 / TICK_RATE);
+        println!("Game tick loop started at {} TPS.", TICK_RATE);
+
+        let mut server = Server::start_server();
+
+        let mut next_tick = Instant::now();
+
+        loop {
+            let mut ticks: u128 = 0;
+            // Logic
+            for dimension in server.dimensions.values_mut() {
+                dimension.load_chunks();
+            }
+
+            if ticks % 60 == 0 {
+                println!("60 ticks one second!");
+            }
+            
+            // Send a dummy message to the main thread to show it's ticking
+            // Later on, this will be a message with updated game state
+            tx_server.send("tick".to_string()).unwrap();
+
+            // Increment tick count
+            ticks += 1;
+
+            // Sleep until the next tick
+            next_tick += tick_duration;
+            let now = Instant::now();
+            if next_tick > now {
+                std::thread::sleep(next_tick - now);
+            } else {
+                next_tick = now + tick_duration;
+            }
+        }
+    });
 
     // Spawn a thread that reads terminal input
     std::thread::spawn(move || {
+        println!("Terminal input thread spawned");
         use std::io::{self, BufRead};
         let stdin = io::stdin();
         for line in stdin.lock().lines() {
             let cmd = line.unwrap().to_lowercase();
 
-            tx.send(cmd).unwrap();
+            tx_input.send(cmd).unwrap();
         }
+        println!("Terminal input thread shut down");
     });
 
     event_loop.run_app(&mut app).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,13 +14,13 @@ use crate::{common::Environment, engine::server::{constants::TICK_RATE, server::
 fn main() {
     env_logger::init();
 
-    let (tx_input, rx_input) = std::sync::mpsc::channel::<String>();
+    let (tx_console, rx_console) = std::sync::mpsc::channel::<String>();
     let (tx_server, rx_server) = std::sync::mpsc::channel::<String>();
 
     let event_loop = EventLoop::new().unwrap();
     event_loop.set_control_flow(ControlFlow::Poll);
 
-    let mut app: App = App::new(rx_input, rx_server);
+    let mut app: App = App::new(rx_console, rx_server);
     
     // Spawn the server thread
     std::thread::spawn(move || {
@@ -70,7 +70,7 @@ fn main() {
         for line in stdin.lock().lines() {
             let cmd = line.unwrap().to_lowercase();
 
-            tx_input.send(cmd).unwrap();
+            tx_console.send(cmd).unwrap();
         }
         println!("Terminal input thread shut down");
     });


### PR DESCRIPTION
- The server is now independent of the app and runs on its own thread
- Both the server and app have their own channels for communicating with the console thread
- Both the server and app handle their commands on their own
- Some commands are now client or server-specific
- Commands are not interpreted in the console thread, then sent in a new debug command wrapper type to either the server or console
- Main (non-environment-specific commands) are now run on the console thread